### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Pillow
 Flask-SocketIO
-opencv-python
+opencv-python==4.5.4.58
 socketIO-client==0.7.2
 websocket-client==1.2.1
 python-socketio==5.4.0


### PR DESCRIPTION
Newest version of opencv-python (4.6.0) breaks the app.